### PR TITLE
Adapt code for 0.2.12

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+target
+.idea
+*.iml

--- a/src/main/java/org/workspace7/cloud/fabric8/IstioEnricher.java
+++ b/src/main/java/org/workspace7/cloud/fabric8/IstioEnricher.java
@@ -12,6 +12,7 @@ import io.fabric8.maven.core.util.MavenUtil;
 import io.fabric8.maven.docker.config.ImageConfiguration;
 import io.fabric8.maven.enricher.api.BaseEnricher;
 import io.fabric8.maven.enricher.api.EnricherContext;
+import io.fabric8.openshift.api.model.DeploymentConfigSpecBuilder;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
@@ -83,8 +84,8 @@ public class IstioEnricher extends BaseEnricher {
             sidecarArgs.add(proxyArgs[i]);
         }
 
-        builder.accept(new TypedVisitor<DeploymentSpecBuilder>() {
-            public void visit(DeploymentSpecBuilder deploymentSpecBuilder) {
+        builder.accept(new TypedVisitor<DeploymentConfigSpecBuilder>() {
+            public void visit(DeploymentConfigSpecBuilder deploymentConfigSpecBuilder) {
                 if ("yes".equalsIgnoreCase(getConfig(Config.enabled))) {
                     log.info("Adding Istio proxy");
                     String initContainerJson = buildInitContainers();
@@ -148,7 +149,7 @@ public class IstioEnricher extends BaseEnricher {
                     *   readOnly: true
                     */
 
-                    deploymentSpecBuilder
+                    deploymentConfigSpecBuilder
                         .editOrNewTemplate()
                         .editOrNewMetadata()
                         //.addToAnnotations("alpha.istio.io/sidecar", "injected")

--- a/src/main/java/org/workspace7/cloud/fabric8/IstioEnricher.java
+++ b/src/main/java/org/workspace7/cloud/fabric8/IstioEnricher.java
@@ -329,19 +329,8 @@ public class IstioEnricher extends BaseEnricher {
     }
 
     /**
-     *
-     *
-     */
-    protected Map<String, String> istioSecretMap() {
-        Map<String, String> map = new HashMap<>();
-        map.put("defaultMode","420");
-        map.put("optional","true");
-        return map;
-    }
-
-    /**
-     *
-     *
+     *  Generate the volumes to be mounted
+     *  @return - list of {@link VolumeMount}
      */
     protected List<VolumeMount> istioVolumeMounts() {
         List<VolumeMount> volumeMounts = new ArrayList<>();
@@ -365,8 +354,8 @@ public class IstioEnricher extends BaseEnricher {
     }
 
     /**
-     *
-     *
+     *  Generate the volumes
+     *  @return - list of {@link Volume}
      */
     protected List<Volume> istioVolumes() {
         List<Volume> volumes = new ArrayList<>();


### PR DESCRIPTION
- Adapt code for 0.2.12
- Use DeploymentConfigBuilder instead of DeploymentConfig
- Include missing resources such as Volumes, VolumesMounts with secret
- Add new annotation